### PR TITLE
Categorieslist bugfix

### DIFF
--- a/src/features/expense/ExpenseDashboard.tsx
+++ b/src/features/expense/ExpenseDashboard.tsx
@@ -53,7 +53,7 @@ const ExpenseDashboard = () => {
   }
 
   const initialState: newExpenseType = {
-    Date: '',
+    Date: DateFetcher(),
     Amount: '',
     Comment: '',
     UserId: user.userId,
@@ -125,7 +125,7 @@ const ExpenseDashboard = () => {
   }
 
   function getCategories(): any {
-    GetUserCreatedCatogories(user.userId).then((Response) => {
+    GetCategoriesForUser(user.userId).then((Response) => {
       setCategories(Response)
     })
   }


### PR DESCRIPTION
Fixar en liten bugg.
När man skapade en ny kategori direkt i ExpenseDashboard uppdaterades inte CategoryList korrekt. Den hämtade bara ur Kategorier som User hade skapat. Nu hämtar den alla som User får använda.